### PR TITLE
[v1.0.2] Add security patches

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,11 @@ $ yarn test
 
 ## Changelog
 
+### v1.0.2
+
+Fixed security bugs with:
+- `mixin-deep` by bumping to `1.3.2`
+
 ### v1.0.1
 
 Fixed security bug with `handlebars` by bumping to `4.5.3`

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,6 +132,7 @@ $ yarn test
 Fixed security bugs with:
 - `mixin-deep` by bumping from `1.3.1` to `1.3.2`
 - `set-value` by bumping from `2.0.0` to `2.0.1`
+- `serialize-javascript` by bumping from `1.4.0` to `2.1.1`
 
 ### v1.0.1
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,16 @@ Run the following command
 $ yarn test
 ```
 
+## Changelog
+
+### v1.0.1
+
+Fixed security bug with `handlebars` by bumping to `4.5.3`
+
+### v1.0.0
+
+Initial release
+
 ## Contributing
 
 We strictly adhere to the [Contributor Covenant](../CODE-OF-CONDUCT.md) in this repository, and wish to foster an open source culture that's welcoming and diverse.

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,11 +130,12 @@ $ yarn test
 ### v1.0.2
 
 Fixed security bugs with:
-- `mixin-deep` by bumping to `1.3.2`
+- `mixin-deep` by bumping from `1.3.1` to `1.3.2`
+- `set-value` by bumping from `2.0.0` to `2.0.1`
 
 ### v1.0.1
 
-Fixed security bug with `handlebars` by bumping to `4.5.3`
+Fixed security bug with `handlebars` by bumping from `4.1.2` to `4.5.3`
 
 ### v1.0.0
 

--- a/loader/package.json
+++ b/loader/package.json
@@ -2,7 +2,7 @@
   "name": "ts-interface-loader",
   "description": "Webpack support for validating TypeScript definitions at runtime.",
   "license": "Apache-2.0",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "typescript",
     "webpack",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.5",
     "prettier": "^1.16.4",
-    "typescript": "^3.3.3333",
     "tslint": "^5.14.0",
-    "tslint-config-prettier": "^1.18.0"
+    "tslint-config-prettier": "^1.18.0",
+    "typescript": "^3.3.3333"
   },
   "scripts": {
     "build": "yarn --cwd loader/ build && yarn --cwd example/ build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5301,10 +5301,10 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
-serialize-javascript@^1.4.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
-  integrity sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==
+serialize-javascript@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.1.tgz#952907a04a3e3a75af7f73d92d15e233862048b2"
+  integrity sha512-MPLPRpD4FNqWq9tTIjYG5LesFouDhdyH0EPY3gVK4DRD5+g4aDqdNSzLIwceulo3Yj+PL1bPh6laE5+H6LTcrQ==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -5726,7 +5726,7 @@ terser-webpack-plugin@^1.1.0:
     cacache "^11.0.2"
     find-cache-dir "^2.0.0"
     schema-utils "^1.0.0"
-    serialize-javascript "^1.4.0"
+    serialize-javascript "^2.1.1"
     source-map "^0.6.1"
     terser "^3.16.1"
     webpack-sources "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5322,9 +5322,9 @@ set-value@^0.4.3:
     to-object-path "^0.3.0"
 
 set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
-  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"


### PR DESCRIPTION
- Added changelog

Fixed security bugs with:
- `mixin-deep` by bumping from `1.3.1` to `1.3.2`
- `set-value` by bumping from `2.0.0` to `2.0.1`
- `serialize-javascript` by bumping from `1.4.0` to `2.1.1`